### PR TITLE
document as obsolete and not reproducible-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Reproducible Plugin for Apache Maven
+# Reproducible Plugin for Apache Maven (obsolete)
 
-A simple [Apache Maven](http://maven.apache.org) plugin to provide support for the new [reproducible build](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) features of Apache Maven and its related plugins.
+A simple [Apache Maven](http://maven.apache.org) plugin to provide some tests for the new [reproducible build](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) features of Apache Maven and its related plugins.
 
 This plugin is designed to be run as part of both the `preparationGoals` and `completionGoals` element of the [Maven Release Plugin](https://maven.apache.org/maven-release/maven-release-plugin/).
 
@@ -11,6 +11,12 @@ When applied, any pom in the current maven session will be rewritten to include 
     <project.build.outputTimestamp>2019-11-09T05:12:36Z</project.build.outputTimestamp>
   </properties>
 ```
+
+Notice that the value of the `project.build.outputTimestamp` property injected is "now", then **NOT** reproducible: **DO NOT EXPECT THIS PLUGIN TO MAKE YOUR BUILD REPRODUCIBLE**. This plugin was only useful in 2019'Q3 to make early tests.
+
+Nowadays:
+1. add explicitely the `project.build.outputTimestamp` property to your reactor parent POM with your value of choice: the value is reproducible as it is simply written in the pom.xml,
+2. let maven-release-plugin 3.0.0-M1 (see [MRELEASE-1029](https://issues.apache.org/jira/browse/MRELEASE-1029)) update the value of the timestamp during the release while it's doing other pom.xml updates, to get a `project.build.outputTimestamp` value that meet release expectations while remaining reproducible (simply written in pom.xml)
 
 ## Configuration
 
@@ -37,3 +43,5 @@ When applied, any pom in the current maven session will be rewritten to include 
 
 * 1.0.1
   * Initial Release
+
+* 2020Q1: mark this test plugin as obsolete, as it does not make build reproducible and is replaced by maven-release-plugin 3.0.0-M1 (see [MRELEASE-1029](https://issues.apache.org/jira/browse/MRELEASE-1029))


### PR DESCRIPTION
this was a test but does not make buidls reproducible, because injected value is not reproducible (= now)

some people use this plugin thinking it will make their build reproducible: we need to make it clear that it does not make builds reproducible